### PR TITLE
Makefile modifications to cross-compile for OpenWRT on OSX

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -21,7 +21,18 @@ CPPFLAGS += -Wno-strict-aliasing
 ###########################################################################
 # System Support
 
-UNAME := $(shell uname)
+SYS := $(shell $(CXX) -dumpmachine)
+
+ifneq (, $(findstring linux, $(SYS)))
+UNAME := Linux
+endif
+ifneq (, $(findstring mingw, $(SYS)))
+UNAME := MINGW32
+endif
+ifneq (, $(findstring darwin, $(SYS)))
+UNAME := Darwin
+endif
+
 MINGW := $(findstring MINGW32, $(UNAME))
 LIBS += -lstdc++ -lm
 VERSION := $(shell git describe --match "fcserver-*")
@@ -169,7 +180,8 @@ CXXFLAGS += -felide-constructors -fno-exceptions -fno-rtti
 
 OBJS := $(CPP_FILES:.cpp=.o) $(C_FILES:.c=.o)
 
-all: $(TARGET)
+print-%: ; @echo $* = $($*)
+all: print-SYS $(TARGET)
 
 # FIXME: A race condition between objects regeneration and their source mtime in make ? 
 $(TARGET): $(SUBMODULES_TARGETS) $(OBJS)


### PR DESCRIPTION
I had trouble cross-compiling on OSX as `uname` will return `Darwin`, when the target platform is something else.  I used a modified version of this stackoverflow answer to get the target from the compiler and use that instead.
http://stackoverflow.com/questions/714100/os-detecting-makefile/12351276#12351276

Tested on OSX only, needs testing on Windows and Linux

There's probably a better way to match strings, I'm not a Makefile expert and you probably have a preferred way to do it.  I left in echoing `SYS` during compilation for debug only.