### PR TITLE
Explicit casts for Processing 3 TweakMode compatibility.

### DIFF
--- a/examples/processing/grid24x8z_clouds/OPC.pde
+++ b/examples/processing/grid24x8z_clouds/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid24x8z_dot/OPC.pde
+++ b/examples/processing/grid24x8z_dot/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid24x8z_flashy_rings/OPC.pde
+++ b/examples/processing/grid24x8z_flashy_rings/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid24x8z_rings/OPC.pde
+++ b/examples/processing/grid24x8z_rings/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid24x8z_rings_leapmotion/OPC.pde
+++ b/examples/processing/grid24x8z_rings_leapmotion/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid24x8z_sequencer/OPC.pde
+++ b/examples/processing/grid24x8z_sequencer/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid24x8z_text/OPC.pde
+++ b/examples/processing/grid24x8z_text/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid24x8z_waves/OPC.pde
+++ b/examples/processing/grid24x8z_waves/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_attractor/OPC.pde
+++ b/examples/processing/grid32x16z_attractor/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_dot/OPC.pde
+++ b/examples/processing/grid32x16z_dot/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_particle_fft/OPC.pde
+++ b/examples/processing/grid32x16z_particle_fft/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_particle_fft_input/OPC.pde
+++ b/examples/processing/grid32x16z_particle_fft_input/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_red/OPC.pde
+++ b/examples/processing/grid32x16z_red/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_rings/OPC.pde
+++ b/examples/processing/grid32x16z_rings/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_rings_lamp/OPC.pde
+++ b/examples/processing/grid32x16z_rings_lamp/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_video/OPC.pde
+++ b/examples/processing/grid32x16z_video/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_wavefronts/OPC.pde
+++ b/examples/processing/grid32x16z_wavefronts/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid32x16z_wavefronts_leapmotion/OPC.pde
+++ b/examples/processing/grid32x16z_wavefronts_leapmotion/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid8x8_dot/OPC.pde
+++ b/examples/processing/grid8x8_dot/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid8x8_noise_simple/OPC.pde
+++ b/examples/processing/grid8x8_noise_simple/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid8x8_orbits/OPC.pde
+++ b/examples/processing/grid8x8_orbits/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/grid8x8_wavefronts/OPC.pde
+++ b/examples/processing/grid8x8_wavefronts/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/ring24_dot/OPC.pde
+++ b/examples/processing/ring24_dot/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/ring24_spin/OPC.pde
+++ b/examples/processing/ring24_spin/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/strip64_dot/OPC.pde
+++ b/examples/processing/strip64_dot/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/strip64_flames/OPC.pde
+++ b/examples/processing/strip64_flames/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/strip64_unmapped/OPC.pde
+++ b/examples/processing/strip64_unmapped/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/template/OPC.pde
+++ b/examples/processing/template/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/triangle16_attractor/OPC.pde
+++ b/examples/processing/triangle16_attractor/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/triangle16_dot/OPC.pde
+++ b/examples/processing/triangle16_dot/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/triangle16_ember/OPC.pde
+++ b/examples/processing/triangle16_ember/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/triangle16_particle_fft/OPC.pde
+++ b/examples/processing/triangle16_particle_fft/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/triangle16_particle_fft_input/OPC.pde
+++ b/examples/processing/triangle16_particle_fft_input/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/triangle16_rings/OPC.pde
+++ b/examples/processing/triangle16_rings/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/triangle16_snake/OPC.pde
+++ b/examples/processing/triangle16_snake/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-

--- a/examples/processing/triangle16_wavefronts/OPC.pde
+++ b/examples/processing/triangle16_wavefronts/OPC.pde
@@ -171,15 +171,15 @@ public class OPC implements Runnable
     }
  
     byte[] packet = new byte[9];
-    packet[0] = 0;          // Channel (reserved)
+    packet[0] = (byte)0x00; // Channel (reserved)
     packet[1] = (byte)0xFF; // Command (System Exclusive)
-    packet[2] = 0;          // Length high byte
-    packet[3] = 5;          // Length low byte
-    packet[4] = 0x00;       // System ID high byte
-    packet[5] = 0x01;       // System ID low byte
-    packet[6] = 0x00;       // Command ID high byte
-    packet[7] = 0x02;       // Command ID low byte
-    packet[8] = firmwareConfig;
+    packet[2] = (byte)0x00; // Length high byte
+    packet[3] = (byte)0x05; // Length low byte
+    packet[4] = (byte)0x00; // System ID high byte
+    packet[5] = (byte)0x01; // System ID low byte
+    packet[6] = (byte)0x00; // Command ID high byte
+    packet[7] = (byte)0x02; // Command ID low byte
+    packet[8] = (byte)firmwareConfig;
 
     try {
       pending.write(packet);
@@ -203,14 +203,14 @@ public class OPC implements Runnable
     byte[] content = colorCorrection.getBytes();
     int packetLen = content.length + 4;
     byte[] header = new byte[8];
-    header[0] = 0;          // Channel (reserved)
-    header[1] = (byte)0xFF; // Command (System Exclusive)
-    header[2] = (byte)(packetLen >> 8);
-    header[3] = (byte)(packetLen & 0xFF);
-    header[4] = 0x00;       // System ID high byte
-    header[5] = 0x01;       // System ID low byte
-    header[6] = 0x00;       // Command ID high byte
-    header[7] = 0x01;       // Command ID low byte
+    header[0] = (byte)0x00;               // Channel (reserved)
+    header[1] = (byte)0xFF;               // Command (System Exclusive)
+    header[2] = (byte)(packetLen >> 8);   // Length high byte
+    header[3] = (byte)(packetLen & 0xFF); // Length low byte
+    header[4] = (byte)0x00;               // System ID high byte
+    header[5] = (byte)0x01;               // System ID low byte
+    header[6] = (byte)0x00;               // Command ID high byte
+    header[7] = (byte)0x01;               // Command ID low byte
 
     try {
       pending.write(header);
@@ -272,10 +272,10 @@ public class OPC implements Runnable
     if (packetData == null || packetData.length != packetLen) {
       // Set up our packet buffer
       packetData = new byte[packetLen];
-      packetData[0] = 0;  // Channel
-      packetData[1] = 0;  // Command (Set pixel colors)
-      packetData[2] = (byte)(numBytes >> 8);
-      packetData[3] = (byte)(numBytes & 0xFF);
+      packetData[0] = (byte)0x00;              // Channel
+      packetData[1] = (byte)0x00;              // Command (Set pixel colors)
+      packetData[2] = (byte)(numBytes >> 8);   // Length high byte
+      packetData[3] = (byte)(numBytes & 0xFF); // Length low byte
     }
   }
   
@@ -368,4 +368,3 @@ public class OPC implements Runnable
     }
   }
 }
-


### PR DESCRIPTION
Fixes issue preventing examples from running in Processing 3's immensely useful TweakMode. TweakMode was throwing errors to the tune of "cannot convert from int to byte"... explicitly casting ints to bytes in OCP.pde's packet-assembly code takes care of this.