### PR TITLE
Add "flip" argument to ledGrid() and ledGrid8x8()

### DIFF
--- a/doc/processing_opc_client.md
+++ b/doc/processing_opc_client.md
@@ -107,7 +107,7 @@ This section lists all public methods available on the OPC object:
 
 ----
 
-* **opc.ledGrid**(*index*, *stripLength*, *numStrips*, *x*, *y*, *ledSpacing*, *stripSpacing*, *angle*, *zigzag*)
+* **opc.ledGrid**(*index*, *stripLength*, *numStrips*, *x*, *y*, *ledSpacing*, *stripSpacing*, *angle*, *zigzag*, *flip*)
   * Place a rigid grid of LEDs on the screen
   * *index*: Number for the first LED in the grid, starting with zero
   * *stripLength*: How long is each strip in the grid?
@@ -117,16 +117,18 @@ This section lists all public methods available on the OPC object:
   * *stripSpacing*: Spacing between strips, in pixels
   * *angle*: Angle, in radians. Positive is clockwise. 0 has pixels in a strip going left-to-right and strips going top-to-bottom.
   * *zigzag*: true = Every other strip is reversed, false = All strips are non-reversed
+  * *flip*: true = All strips are reversed, false = All strips are non-reversed
  
 ----
 
-* **opc.ledGrid8x8**(*index*, *x*, *y*, *spacing*, *angle*, *zigzag*)
+* **opc.ledGrid8x8**(*index*, *x*, *y*, *spacing*, *angle*, *zigzag*, *flip*)
   * Convenience method for placing an 8x8 grid of LEDs on the screen
   * *index*: Number for the first LED in the grid, starting with zero
   * *x*, *y*: Center location, in pixels
   * *spacing*: Spacing between LEDs and strips, in pixels
   * *angle*: Angle, in radians. Positive is clockwise. 0 has pixels in a strip going left-to-right and strips going top-to-bottom.
   * *zigzag*: true = Every other strip is reversed, false = All strips are non-reversed
+  * *flip*: true = All strips are reversed, false = All strips are non-reversed
   
 ----
 

--- a/examples/processing/grid24x8z_clouds/OPC.pde
+++ b/examples/processing/grid24x8z_clouds/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid24x8z_clouds/grid24x8z_clouds.pde
+++ b/examples/processing/grid24x8z_clouds/grid24x8z_clouds.pde
@@ -10,11 +10,11 @@ void setup()
 
   // Map an 8x8 grid of LEDs to the center of the window, scaled to take up most of the space
   float spacing = height / 10.0;
-  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true);
+  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true, false);
 
   // Put two more 8x8 grids to the left and to the right of that one.
-  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true);
-  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true);
+  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true, false);
+  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true, false);
   
   // Make the status LED quiet
   opc.setStatusLed(false);

--- a/examples/processing/grid24x8z_dot/OPC.pde
+++ b/examples/processing/grid24x8z_dot/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid24x8z_dot/grid24x8z_dot.pde
+++ b/examples/processing/grid24x8z_dot/grid24x8z_dot.pde
@@ -12,11 +12,11 @@ void setup()
 
   // Map an 8x8 grid of LEDs to the center of the window, scaled to take up most of the space
   float spacing = height / 16.0;
-  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true);
+  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true, false);
 
   // Put two more 8x8 grids to the left and to the right of that one.
-  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true);
-  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true);
+  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true, false);
+  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true, false);
 }
 
 void draw()

--- a/examples/processing/grid24x8z_flashy_rings/OPC.pde
+++ b/examples/processing/grid24x8z_flashy_rings/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid24x8z_flashy_rings/grid24x8z_flashy_rings.pde
+++ b/examples/processing/grid24x8z_flashy_rings/grid24x8z_flashy_rings.pde
@@ -11,11 +11,11 @@ void setup()
 
   // Map an 8x8 grid of LEDs to the center of the window, scaled to take up most of the space
   float spacing = height / 10.0;
-  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true);
+  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true, false);
 
   // Put two more 8x8 grids to the left and to the right of that one.
-  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true);
-  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true);
+  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true, false);
+  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true, false);
 
   // Make the status LED quiet
   opc.setStatusLed(false);

--- a/examples/processing/grid24x8z_rings/OPC.pde
+++ b/examples/processing/grid24x8z_rings/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid24x8z_rings/grid24x8z_rings.pde
+++ b/examples/processing/grid24x8z_rings/grid24x8z_rings.pde
@@ -11,11 +11,11 @@ void setup()
 
   // Map an 8x8 grid of LEDs to the center of the window, scaled to take up most of the space
   float spacing = height / 10.0;
-  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true);
+  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true, false);
 
   // Put two more 8x8 grids to the left and to the right of that one.
-  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true);
-  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true);
+  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true, false);
+  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true, false);
 
   // Make the status LED quiet
   opc.setStatusLed(false);

--- a/examples/processing/grid24x8z_rings_leapmotion/OPC.pde
+++ b/examples/processing/grid24x8z_rings_leapmotion/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid24x8z_rings_leapmotion/grid24x8z_rings_leapmotion.pde
+++ b/examples/processing/grid24x8z_rings_leapmotion/grid24x8z_rings_leapmotion.pde
@@ -18,11 +18,11 @@ void setup()
 
   // Map an 8x8 grid of LEDs to the center of the window, scaled to take up most of the space
   float spacing = height / 10.0;
-  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true);
+  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true, false);
 
   // Put two more 8x8 grids to the left and to the right of that one.
-  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true);
-  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true);
+  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true, false);
+  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true, false);
   
   // Make the status LED quiet
   opc.setStatusLed(false);

--- a/examples/processing/grid24x8z_sequencer/OPC.pde
+++ b/examples/processing/grid24x8z_sequencer/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid24x8z_sequencer/grid24x8z_sequencer.pde
+++ b/examples/processing/grid24x8z_sequencer/grid24x8z_sequencer.pde
@@ -72,9 +72,9 @@ void setup()
   opc = new OPC(this, "127.0.0.1", 7890);
 
   // Three 8x8 grids side by side
-  opc.ledGrid8x8(0, ledX, ledY, ledSpacing, 0, true);
-  opc.ledGrid8x8(64, ledX - ledSpacing * 8, ledY, ledSpacing, 0, true);
-  opc.ledGrid8x8(128, ledX + ledSpacing * 8, ledY, ledSpacing, 0, true);
+  opc.ledGrid8x8(0, ledX, ledY, ledSpacing, 0, true, false);
+  opc.ledGrid8x8(64, ledX - ledSpacing * 8, ledY, ledSpacing, 0, true, false);
+  opc.ledGrid8x8(128, ledX + ledSpacing * 8, ledY, ledSpacing, 0, true, false);
   
   // Init timekeeping, start the pattern from the beginning
   startPattern();

--- a/examples/processing/grid24x8z_text/OPC.pde
+++ b/examples/processing/grid24x8z_text/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid24x8z_text/grid24x8z_text.pde
+++ b/examples/processing/grid24x8z_text/grid24x8z_text.pde
@@ -17,11 +17,11 @@ void setup()
 
   // Map an 8x8 grid of LEDs to the center of the window, scaled to take up most of the space
   float spacing = height / 16.0;
-  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true);
+  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true, false);
 
   // Put two more 8x8 grids to the left and to the right of that one.
-  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true);
-  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true);
+  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true, false);
+  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true, false);
 
   // Create the font
   f = createFont("Futura", 200);

--- a/examples/processing/grid24x8z_waves/OPC.pde
+++ b/examples/processing/grid24x8z_waves/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid24x8z_waves/grid24x8z_waves.pde
+++ b/examples/processing/grid24x8z_waves/grid24x8z_waves.pde
@@ -18,9 +18,9 @@ void setup() {
 
   opc = new OPC(this, "127.0.0.1", 7890);
   float spacing = height / 16.0;
-  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true);
-  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true);
-  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true);
+  opc.ledGrid8x8(0, width/2, height/2, spacing, 0, true, false);
+  opc.ledGrid8x8(64, width/2 - spacing * 8, height/2, spacing, 0, true, false);
+  opc.ledGrid8x8(128, width/2 + spacing * 8, height/2, spacing, 0, true, false);
   
   // Initial color correction settings
   mouseMoved();

--- a/examples/processing/grid32x16z_attractor/OPC.pde
+++ b/examples/processing/grid32x16z_attractor/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_attractor/grid32x16z_attractor.pde
+++ b/examples/processing/grid32x16z_attractor/grid32x16z_attractor.pde
@@ -29,14 +29,14 @@ void setup()
   // Connect to the local instance of fcserver
   opc = new OPC(this, "127.0.0.1", 7890);
 
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 
   // Attraction points
   corners = new PVector[3];

--- a/examples/processing/grid32x16z_dot/OPC.pde
+++ b/examples/processing/grid32x16z_dot/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_dot/grid32x16z_dot.pde
+++ b/examples/processing/grid32x16z_dot/grid32x16z_dot.pde
@@ -10,14 +10,14 @@ void setup()
   // Connect to the local instance of fcserver. You can change this line to connect to another computer's fcserver
   opc = new OPC(this, "127.0.0.1", 7890);
 
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 }
 
 void draw()

--- a/examples/processing/grid32x16z_particle_fft/OPC.pde
+++ b/examples/processing/grid32x16z_particle_fft/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_particle_fft/grid32x16z_particle_fft.pde
+++ b/examples/processing/grid32x16z_particle_fft/grid32x16z_particle_fft.pde
@@ -40,14 +40,14 @@ void setup()
   // Connect to the local instance of fcserver
   opc = new OPC(this, "127.0.0.1", 7890);
 
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 }
 
 void draw()

--- a/examples/processing/grid32x16z_particle_fft_input/OPC.pde
+++ b/examples/processing/grid32x16z_particle_fft_input/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_particle_fft_input/grid32x16z_particle_fft_input.pde
+++ b/examples/processing/grid32x16z_particle_fft_input/grid32x16z_particle_fft_input.pde
@@ -38,14 +38,14 @@ void setup()
   // Connect to the local instance of fcserver
   opc = new OPC(this, "127.0.0.1", 7890);
 
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 }
 
 void draw()

--- a/examples/processing/grid32x16z_red/OPC.pde
+++ b/examples/processing/grid32x16z_red/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_red/grid32x16z_red.pde
+++ b/examples/processing/grid32x16z_red/grid32x16z_red.pde
@@ -22,14 +22,14 @@ void setup()
   // Connect to the local instance of fcserver. You can change this line to connect to another computer's fcserver
   opc = new OPC(this, "127.0.0.1", 7890);
 
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
   
   float stripSpacing = 2;
   float stripX = width * 0.35;

--- a/examples/processing/grid32x16z_rings/OPC.pde
+++ b/examples/processing/grid32x16z_rings/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_rings/grid32x16z_rings.pde
+++ b/examples/processing/grid32x16z_rings/grid32x16z_rings.pde
@@ -9,14 +9,14 @@ void setup()
   // Connect to the local instance of fcserver. You can change this line to connect to another computer's fcserver
   opc = new OPC(this, "127.0.0.1", 7890);
 
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 
   // Make the status LED quiet
   opc.setStatusLed(false);

--- a/examples/processing/grid32x16z_rings_lamp/OPC.pde
+++ b/examples/processing/grid32x16z_rings_lamp/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_rings_lamp/grid32x16z_rings_lamp.pde
+++ b/examples/processing/grid32x16z_rings_lamp/grid32x16z_rings_lamp.pde
@@ -13,14 +13,14 @@ void setup()
   // Connect to the local instance of fcserver. You can change this line to connect to another computer's fcserver
   opc = new OPC(this, "127.0.0.1", 7890);
 
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 
   // Make the status LED quiet
   opc.setStatusLed(false);

--- a/examples/processing/grid32x16z_video/OPC.pde
+++ b/examples/processing/grid32x16z_video/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_video/grid32x16z_video.pde
+++ b/examples/processing/grid32x16z_video/grid32x16z_video.pde
@@ -20,14 +20,14 @@ void setup()
   // Connect to the local instance of fcserver. You can change this line to connect to another computer's fcserver
   opc = new OPC(this, "127.0.0.1", 7890);
 
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 
   movie = new Movie(this, filename);
   movie.loop();

--- a/examples/processing/grid32x16z_wavefronts/OPC.pde
+++ b/examples/processing/grid32x16z_wavefronts/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_wavefronts/grid32x16z_wavefronts.pde
+++ b/examples/processing/grid32x16z_wavefronts/grid32x16z_wavefronts.pde
@@ -48,14 +48,14 @@ void setup()
   texture = loadImage("ring.png");
 
   opc = new OPC(this, "127.0.0.1", 7890);
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 
   // We can have up to 100 rings. They all start out invisible.
   rings = new Ring[100];

--- a/examples/processing/grid32x16z_wavefronts_leapmotion/OPC.pde
+++ b/examples/processing/grid32x16z_wavefronts_leapmotion/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid32x16z_wavefronts_leapmotion/grid32x16z_wavefronts_leapmotion.pde
+++ b/examples/processing/grid32x16z_wavefronts_leapmotion/grid32x16z_wavefronts_leapmotion.pde
@@ -55,14 +55,14 @@ void setup()
   leap = new LeapMotion(this);
 
   opc = new OPC(this, "127.0.0.1", 7890);
-  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true);
-  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true);
-  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true);
+  opc.ledGrid8x8(0 * 64, width * 1/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(1 * 64, width * 3/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(2 * 64, width * 5/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(3 * 64, width * 7/8, height * 1/4, height/16, 0, true, false);
+  opc.ledGrid8x8(4 * 64, width * 1/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(5 * 64, width * 3/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(6 * 64, width * 5/8, height * 3/4, height/16, 0, true, false);
+  opc.ledGrid8x8(7 * 64, width * 7/8, height * 3/4, height/16, 0, true, false);
 
   // We can have up to 100 rings. They all start out invisible.
   rings = new Ring[100];

--- a/examples/processing/grid8x8_dot/OPC.pde
+++ b/examples/processing/grid8x8_dot/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid8x8_dot/grid8x8_dot.pde
+++ b/examples/processing/grid8x8_dot/grid8x8_dot.pde
@@ -12,7 +12,7 @@ void setup()
   opc = new OPC(this, "127.0.0.1", 7890);
 
   // Map an 8x8 grid of LEDs to the center of the window
-  opc.ledGrid8x8(0, width/2, height/2, height / 12.0, 0, false);
+  opc.ledGrid8x8(0, width/2, height/2, height / 12.0, 0, false, false);
 }
 
 void draw()

--- a/examples/processing/grid8x8_noise_simple/OPC.pde
+++ b/examples/processing/grid8x8_noise_simple/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid8x8_noise_simple/grid8x8_noise_simple.pde
+++ b/examples/processing/grid8x8_noise_simple/grid8x8_noise_simple.pde
@@ -15,7 +15,7 @@ void setup()
   clouds = createImage(128, 128, RGB);
 
   opc = new OPC(this, "127.0.0.1", 7890);
-  opc.ledGrid8x8(0, width/2, height/2, height / 8.0, 0, false);
+  opc.ledGrid8x8(0, width/2, height/2, height / 8.0, 0, false, false);
 }
 
 void draw()

--- a/examples/processing/grid8x8_orbits/OPC.pde
+++ b/examples/processing/grid8x8_orbits/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid8x8_orbits/grid8x8_orbits.pde
+++ b/examples/processing/grid8x8_orbits/grid8x8_orbits.pde
@@ -14,7 +14,7 @@ void setup()
 
   // Map an 8x8 grid of LEDs to the center of the window, scaled to take up most of the space
   float spacing = height / 14.0;
-  opc.ledGrid8x8(0, width/2, height/2, spacing, HALF_PI, false);
+  opc.ledGrid8x8(0, width/2, height/2, spacing, HALF_PI, false, false);
 }
 
 float px, py;

--- a/examples/processing/grid8x8_wavefronts/OPC.pde
+++ b/examples/processing/grid8x8_wavefronts/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/grid8x8_wavefronts/grid8x8_wavefronts.pde
+++ b/examples/processing/grid8x8_wavefronts/grid8x8_wavefronts.pde
@@ -48,7 +48,7 @@ void setup()
   texture = loadImage("ring.png");
 
   opc = new OPC(this, "127.0.0.1", 7890);
-  opc.ledGrid8x8(0, width/2, height/2, height / 16.0, 0, false);
+  opc.ledGrid8x8(0, width/2, height/2, height / 16.0, 0, false, false);
 
   // We can have up to 100 rings. They all start out invisible.
   rings = new Ring[100];

--- a/examples/processing/ring24_dot/OPC.pde
+++ b/examples/processing/ring24_dot/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/ring24_spin/OPC.pde
+++ b/examples/processing/ring24_spin/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/strip64_dot/OPC.pde
+++ b/examples/processing/strip64_dot/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/strip64_flames/OPC.pde
+++ b/examples/processing/strip64_flames/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/strip64_unmapped/OPC.pde
+++ b/examples/processing/strip64_unmapped/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/template/OPC.pde
+++ b/examples/processing/template/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/triangle16_attractor/OPC.pde
+++ b/examples/processing/triangle16_attractor/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/triangle16_dot/OPC.pde
+++ b/examples/processing/triangle16_dot/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/triangle16_ember/OPC.pde
+++ b/examples/processing/triangle16_ember/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/triangle16_particle_fft/OPC.pde
+++ b/examples/processing/triangle16_particle_fft/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/triangle16_particle_fft_input/OPC.pde
+++ b/examples/processing/triangle16_particle_fft_input/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/triangle16_rings/OPC.pde
+++ b/examples/processing/triangle16_rings/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/triangle16_snake/OPC.pde
+++ b/examples/processing/triangle16_snake/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.

--- a/examples/processing/triangle16_wavefronts/OPC.pde
+++ b/examples/processing/triangle16_wavefronts/OPC.pde
@@ -77,7 +77,8 @@ public class OPC implements Runnable
   // at 'angle', measured in radians clockwise from +X.
   // (x,y) is the center of the grid.
   void ledGrid(int index, int stripLength, int numStrips, float x, float y,
-               float ledSpacing, float stripSpacing, float angle, boolean zigzag)
+               float ledSpacing, float stripSpacing, float angle, boolean zigzag,
+               boolean flip)
   {
     float s = sin(angle + HALF_PI);
     float c = cos(angle + HALF_PI);
@@ -85,15 +86,16 @@ public class OPC implements Runnable
       ledStrip(index + stripLength * i, stripLength,
         x + (i - (numStrips-1)/2.0) * stripSpacing * c,
         y + (i - (numStrips-1)/2.0) * stripSpacing * s, ledSpacing,
-        angle, zigzag && (i % 2) == 1);
+        angle, zigzag && ((i % 2) == 1) != flip);
     }
   }
 
   // Set the location of 64 LEDs arranged in a uniform 8x8 grid.
   // (x,y) is the center of the grid.
-  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag)
+  void ledGrid8x8(int index, float x, float y, float spacing, float angle, boolean zigzag,
+                  boolean flip)
   {
-    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag);
+    ledGrid(index, 8, 8, x, y, spacing, spacing, angle, zigzag, flip);
   }
 
   // Should the pixel sampling locations be visible? This helps with debugging.


### PR DESCRIPTION
The "zigzag" argument is handy to create daisy-chained grids, but what
if we want to start from the other side? I don't think rotation gets us
there, but this does.
