### PR TITLE
Support reverse mappings for Fadecandy strips.

### DIFF
--- a/doc/fc_server_config.md
+++ b/doc/fc_server_config.md
@@ -102,6 +102,8 @@ Supported mapping objects for Fadecandy devices:
     * The "Color channels" must be a 3-letter string, where each letter corresponds to one of the WS2811 outputs.
     * Each letter can be "r", "g", or "b" to choose the red, green, or blue channel respectively, or "l" to use the average luminosity.
 
+If the pixel count is negative, the output pixels are mapped in reverse order starting at the first output pixel index and decrementing the index for each successive pixel up to the absolute value of the pixel count.
+
 Other settings for Fadecandy devices:
 
 Name         | Values               | Default | Description
@@ -110,7 +112,7 @@ led          | true / false / null  | null    | Is the LED on, off, or under aut
 dither       | true / false         | true    | Is dithering enabled?
 interpolate  | true / false         | true    | Is inter-frame interpolation enabled?
 
-The following example config file supports two Fadecandy devices with distinct serial numbers. They both receive data from OPC channel #0. The first 512 pixels map to the first Fadecandy device. The next 64 pixels map to the entire first strand of the second Fadecandy device, and the next 32 pixels map to the beginning of the third strand with the color channels in Blue, Green, Red order.
+The following example config file supports two Fadecandy devices with distinct serial numbers. They both receive data from OPC channel #0. The first 512 pixels map to the first Fadecandy device. The next 64 pixels map to the entire first strand of the second Fadecandy device, the next 32 pixels map to the beginning of the third strand with the color channels in Blue, Green, Red order, and the next 32 pixels map to the end of the third strand in reverse order.
 
     {
         "listen": ["127.0.0.1", 7890],
@@ -136,6 +138,7 @@ The following example config file supports two Fadecandy devices with distinct s
                 "map": [
                     [ 0, 512, 0, 64 ],
                     [ 0, 576, 128, 32, "bgr" ]
+                    [ 0, 608, 191, -32 ]
                 ]
             }
         ]


### PR DESCRIPTION
Use negative count to map pixels in reverse order along a strip.

This is useful for implementing matrices which reverse logical and physical orientation for certain segments.
