### PR TITLE
Fix CMAKE instructions

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -52,6 +52,7 @@ To build the binaries and get a Debian package:
 
 
 ```bash
+$ make submodules # Fetches submodule git repositories
 $ mkdir build
 $ cd build
 $ cmake ..


### PR DESCRIPTION
Submodules must be present prior to running cmake.