### PR TITLE
Adds OPC message relaying (forwarding) over a second socket

### DIFF
--- a/doc/fc_server_config.md
+++ b/doc/fc_server_config.md
@@ -19,6 +19,7 @@ The configuration file is a JSON object. By default, it looks like this:
 ```
 {
     "listen": ["127.0.0.1", 7890],
+    "relay": NULL,
     "verbose": true,
 
     "color": {
@@ -40,6 +41,7 @@ The configuration file is a JSON object. By default, it looks like this:
 Name     | Summary
 -------- | -------------------------------------------------------
 listen   | What address and port should the server listen on?
+relay    | What address and port should the server relay messages to?
 verbose  | Does the server log anything except errors to the console?
 color    | Default global color correction settings
 devices  | List of configured devices
@@ -52,6 +54,13 @@ By default, fcserver listens on port 7890 on the local (loopback) interface. Thi
 The "listen" configuration key must be a JSON array of the form [**host**, **port**], where **port** is a number and **host** is either a string or *null*. If the host is *null*, fcserver listens on all network interfaces and it's reachable from other computers
 
 *Warning:* Do not run fcserver on an untrusted network. It has no built-in security provisions, so anyone on your network will have control of fcserver. Additionally, bugs in fcserver may compromise the security of your computer.
+
+Relay
+-----
+
+The "relay" configuration key is using the same format as the "listen" configuration key and allows clients to connect on a separate socket to receive a copy of the OPC messages the fcserver is handling.
+
+Relaying is disabled by default.
 
 Color
 -----

--- a/examples/html/grid8x8_dots-relay.html
+++ b/examples/html/grid8x8_dots-relay.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+<!-- Load the Paper.js library -->
+<script type="text/javascript" src="http://paperjs.org/assets/js/paper.js"></script>
+
+<!-- Define inlined PaperScript, and associate it with myCanvas -->
+<script type="text/paperscript" canvas="myCanvas">
+
+    /*
+     * This is a self-contained for controlling Fadecandy from JavaScript.
+     * We use the popular Paper.js library for drawing and vector math,
+     * and we communicate with the LEDs via a WebSocket connection to fcserver.
+     *
+     * The fcserver must be running before loading the page.
+     * Assumes an 8x8 LED matrix in top-down left-right order is connected
+     * to the first channel of an attached Fadecandy board.
+     *
+     * This example is released into the public domain.
+     * Feel free to use it as a starting point for your own projects.
+     *
+     * BROWSER SUPPORT:
+     *   - Firefox: Works really well
+     *   - Safari: Unusable. Runs for a few seconds, then stops.
+     *   - Chrome: Pretty good, but not as fast as Firefox.
+     * 
+     * 2013 Micah Elizabeth Scott
+     */
+
+    // Paint the background black
+    var background = new Path.Rectangle(view.bounds);
+    background.fillColor = 'black';
+
+    // Connect to a Fadecandy server running on the same computer, on a port configured to relay
+    var socket = new WebSocket('ws://127.0.0.1:7891');
+
+    // Options needed for relaying
+    // setting binaryType is required to properly receive the OPC messages
+    socket.binaryType = 'arraybuffer';
+
+    // Handler to receive the messages
+    socket.onmessage = function(event) {
+        packetReceived(event);
+    }
+
+    // Put some connection status text in the corner of the screen
+    var connectionStatus = new PointText(view.bounds.topLeft + new Point(8, 25));
+    connectionStatus.content = 'Connecting to fcserver...';
+    connectionStatus.style = {
+        fontSize: 20,
+        justification: 'left',
+        fillColor: 'white'
+    };
+    socket.onclose = function(event) {
+        connectionStatus.content = "Not connected to fcserver";
+        connectionStatus.style.fillColor = '#f44';
+    }
+    socket.onopen = function(event) {
+        connectionStatus.content = "Connected";
+        connectionStatus.style.fillColor = '#4f4';
+    }
+
+    // Figure out which areas of the screen are going to map to our LEDs.
+    // This example is hardcoded for an 8x8 grid of pixels, organized in a
+    // left-to-right top-down fashion. Each LED is represented by a small
+    // marker showing its location in the scene.
+
+    var leds = []
+    for (var y = 0; y < 8; y++) {
+        for (var x = 0; x < 8; x++) {
+            var spacing = view.bounds.height / 12;
+            var point = view.center + new Point(spacing * (x - 3.5), spacing * (y - 3.5));
+            var marker = new Path.Circle({
+                center: point,
+                radius: spacing * 0.25,
+                strokeColor: '#888',
+                strokeWidth: 1
+            });
+            leds.push(marker);
+        }
+    }
+
+    function packetReceived(event){
+        if (event && event.data && event.data ){
+            var data = new Uint8Array(event.data);
+            if (data.length > 4) {
+                var channel = data[0];
+                var command = data[1]
+                var pixelsRaw = data.slice(4);
+                var pixels = [];
+                var pixel;
+                // each  pixel byte is an RGB
+                for(var i=0; i < pixelsRaw.length; i++){
+                    if (!pixel) {
+                        pixel = { R: pixelsRaw[i] };
+                    }
+                    else if (!pixel.hasOwnProperty('G')) {
+                        pixel.G = pixelsRaw[i];
+                    }
+                    else if (!pixel.hasOwnProperty('B')) {
+                        pixel.B = pixelsRaw[i];
+                    }
+                    if (pixel.hasOwnProperty('B')) {
+                        // pixel is complete
+
+                        // update the LED
+                        var ledIndex = pixels.length;
+                        if (ledIndex < leds.length) {
+                            leds[ledIndex].fillColor = new Color(pixel.R/255, pixel.G/255, pixel.B/255);
+                        }
+
+                        // stash it and reset
+                        pixels.push(pixel);
+                        pixel = undefined;
+                    }
+                }
+            }
+        }
+    }
+
+</script>
+</head>
+<body style="margin: 0">
+    <canvas id="myCanvas" resize></canvas>
+</body>
+</html>

--- a/server/config.json
+++ b/server/config.json
@@ -1,0 +1,19 @@
+{
+    "listen": ["127.0.0.1", 7890],
+    "relay":  [null, 7891],
+    "verbose": true,
+
+    "color": {
+        "gamma": 2.5,
+        "whitepoint": [1.0, 1.0, 1.0]
+    },
+
+    "devices": [
+        {
+            "type": "fadecandy",
+            "map": [
+                [ 0, 0, 0, 512 ]
+            ]
+        }
+    ]
+}

--- a/server/src/fcserver.cpp
+++ b/server/src/fcserver.cpp
@@ -33,6 +33,7 @@
 FCServer::FCServer(rapidjson::Document &config)
     : mConfig(config),
       mListen(config["listen"]),
+      mRelay(config["relay"]),
       mColor(config["color"]),
       mDevices(config["devices"]),
       mVerbose(config["verbose"].IsTrue()),
@@ -64,6 +65,29 @@ FCServer::FCServer(rapidjson::Document &config)
     }
 
     /*
+     * Validate the relay [host, port] list.
+     */
+
+    if (mRelay.IsArray() && mRelay.Size() == 2) {
+        const Value &host = mRelay[0u];
+        const Value &port = mRelay[1];
+        const char *hostStr = 0;
+
+        if (host.IsString()) {
+            hostStr = host.GetString();
+        } else if (!host.IsNull()) {
+            mError << "Hostname in 'relay' must be null (any) or a hostname string.\n";
+        }
+
+        if (!port.IsUint()) {
+            mError << "The 'relay' port must be an integer.\n";
+        }
+    }
+    else if (!mRelay.IsNull()) {
+        mError << "The optional 'relay' configuration key must be a [host, post] list.\n";
+    }
+
+    /*
      * Minimal validation on 'devices'
      */
 
@@ -78,7 +102,16 @@ bool FCServer::start(libusb_context *usb)
     const Value &port = mListen[1];
     const char *hostStr = host.IsString() ? host.GetString() : NULL;
 
-    return mTcpNetServer.start(hostStr, port.GetUint()) && startUSB(usb);
+    bool started = mTcpNetServer.start(hostStr, port.GetUint()) && startUSB(usb);
+
+    if (started && !mRelay.IsNull()) {
+        const Value &relayHost = mRelay[0u];
+        const Value &relayPort = mRelay[1];
+        const char *relayHostStr = relayHost.IsString() ? relayHost.GetString() : NULL;
+        mTcpNetServer.startRelay(relayHostStr, relayPort.GetUint());
+    }
+
+    return started;
 }
 
 bool FCServer::startUSB(libusb_context *usb)
@@ -118,6 +151,9 @@ void FCServer::cbOpcMessage(OPC::Message &msg, void *context)
     }
 
     self->mEventMutex.unlock();
+
+    // also forward the message to clients connected on the relay socket
+    self->mTcpNetServer.relayMessage(msg);
 }
 
 int FCServer::cbHotplug(libusb_context *ctx, libusb_device *device, libusb_hotplug_event event, void *user_data)

--- a/server/src/fcserver.h
+++ b/server/src/fcserver.h
@@ -51,6 +51,7 @@ private:
 
     const Document& mConfig;
     const Value& mListen;
+    const Value& mRelay;
     const Value& mColor;
     const Value& mDevices;
     bool mVerbose;

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -32,6 +32,7 @@
 const char *kDefaultConfig =
     "    {\n"
     "        \"listen\": [\"127.0.0.1\", 7890],\n"
+    "        \"relay\": null,\n"
     "        \"verbose\": true,\n"
     "    \n"
     "        \"color\": {\n"


### PR DESCRIPTION
The use case that inspired this feature was primarily to have running a read-only simulator of the lighting installation.  This allowed development of lighting control scripts to be completed without requiring the physical lights to be connected.  This also for the preview/simulation visual to be written independently of the lighting control scripts.

For example, in one project a simulation visual was coded in three.js (showing the layout of the LED's in a 3D view), while several lighting control scripts were written in python.