### PR TITLE
add vs2017 linux remote project files for raspberry pi 3

### DIFF
--- a/server/vsbuild/vs2017_linux_raspberrypi/server_vs2017_linux_raspberrypi.sln
+++ b/server/vsbuild/vs2017_linux_raspberrypi/server_vs2017_linux_raspberrypi.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2024
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "server", "server_vs2017_linux_raspberrypi.vcxproj", "{0C0A9651-812D-49F1-8B47-6C29242B376D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Release|ARM = Release|ARM
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0C0A9651-812D-49F1-8B47-6C29242B376D}.Debug|ARM.ActiveCfg = Debug|ARM
+		{0C0A9651-812D-49F1-8B47-6C29242B376D}.Debug|ARM.Build.0 = Debug|ARM
+		{0C0A9651-812D-49F1-8B47-6C29242B376D}.Release|ARM.ActiveCfg = Release|ARM
+		{0C0A9651-812D-49F1-8B47-6C29242B376D}.Release|ARM.Build.0 = Release|ARM
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {35E75549-3D4F-4C02-9D69-164FBBD0F8A4}
+	EndGlobalSection
+EndGlobal

--- a/server/vsbuild/vs2017_linux_raspberrypi/server_vs2017_linux_raspberrypi.vcxproj
+++ b/server/vsbuild/vs2017_linux_raspberrypi/server_vs2017_linux_raspberrypi.vcxproj
@@ -1,0 +1,950 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0c0a9651-812d-49f1-8b47-6c29242b376d}</ProjectGuid>
+    <Keyword>Linux</Keyword>
+    <RootNamespace>server_vs2017_linux_raspberrypi</RootNamespace>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <ApplicationType>Linux</ApplicationType>
+    <ApplicationTypeRevision>1.0</ApplicationTypeRevision>
+    <TargetLinuxPlatform>Raspberry</TargetLinuxPlatform>
+    <LinuxProjectType>{8748239F-558C-44D1-944B-07B09C35B330}</LinuxProjectType>
+    <ProjectName>server</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UseOfStl />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UseOfStl />
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <TargetExt />
+    <RemoteProjectDir>$(RemoteRootDir)/$(SolutionName)</RemoteProjectDir>
+    <RemoteCCompileToolExe>cc</RemoteCCompileToolExe>
+    <IncludePath>.;./server;./server/src;./server/libwebsockets/lib;./server/libusbx/libusb;./server/libusbx/libusb/os</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <TargetExt />
+    <RemoteProjectDir>$(RemoteRootDir)/$(SolutionName)</RemoteProjectDir>
+    <RemoteCCompileToolExe>cc</RemoteCCompileToolExe>
+    <IncludePath>.;./server;./server/src;./server/libwebsockets/lib;./server/libusbx/libusb;./server/libusbx/libusb/os</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <Link>
+      <LibraryDependencies>
+      </LibraryDependencies>
+    </Link>
+    <RemotePostBuildEvent>
+      <Command>
+      </Command>
+      <Message>
+      </Message>
+    </RemotePostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <Link>
+      <LibraryDependencies>
+      </LibraryDependencies>
+      <AdditionalDependencies>-lstdc++;-lm;-lpthread;-lrt</AdditionalDependencies>
+      <AdditionalOptions>$(RemoteRootDir)/$(SolutionName)httpdocs.o</AdditionalOptions>
+      <Relocation>
+      </Relocation>
+      <FunctionBinding>false</FunctionBinding>
+      <NoExecStackRequired>false</NoExecStackRequired>
+      <UnresolvedSymbolReferences />
+    </Link>
+    <RemotePostBuildEvent>
+      <Command>
+      </Command>
+      <Message>
+      </Message>
+    </RemotePostBuildEvent>
+    <ClCompile>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>FCSERVER_VERSION=fcserver-1.04-101-g686ab1f;NDEBUG -DLWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <CppLanguageStandard>gnu++11</CppLanguageStandard>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <CAdditionalWarning>no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning>no-strict-aliasing</CppAdditionalWarning>
+      <Verbose>true</Verbose>
+    </ClCompile>
+    <RemotePreLinkEvent>
+      <Command>(cd server/http; python manifest.py) &gt; $(RemoteRootDir)/$(SolutionName)httpdocs.cpp &amp;&amp; g++ -DFCSERVER_VERSION=fcserver-1.04-101-g686ab1f -std=gnu++0x -felide-constructors -fno-exceptions -fno-rtti -Wno-strict-aliasing -Os -DNDEBUG -DLWS_LIBRARY_VERSION= -DLWS_BUILD_HASH= -DLWS_NO_EXTENSIONS -DLWS_NO_CLIENT -DLWS_NO_WSAPOLL -DLWS_NO_DAEMONIZE -DOS_LINUX -DTHREADS_POSIX -DPOLL_NFDS_TYPE=nfds_t -DLIBUSB_CALL= -DDEFAULT_VISIBILITY= -DHAVE_GETTIMEOFDAY -DHAVE_POLL_H -DHAVE_ASM_TYPES_H -DHAVE_SYS_SOCKET_H -DHAVE_LINUX_NETLINK_H -DHAVE_LINUX_FILTER_H -MMD -Iserver/src -Iserver -lserver/rapidjson -Iserver/libwebsockets/lib -Iserver/libusbx/libusb  -c -o $(RemoteRootDir)/$(SolutionName)httpdocs.o $(RemoteRootDir)/$(SolutionName)httpdocs.cpp</Command>
+      <Message>Generating and compiling httpdocs.cpp</Message>
+    </RemotePreLinkEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\libusbx\libusb\hotplug.h" />
+    <ClInclude Include="..\..\libusbx\libusb\libusb.h" />
+    <ClInclude Include="..\..\libusbx\libusb\libusbi.h" />
+    <ClInclude Include="..\..\libusbx\libusb\os\darwin_usb.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\linux_usbfs.h" />
+    <ClInclude Include="..\..\libusbx\libusb\os\poll_posix.h" />
+    <ClInclude Include="..\..\libusbx\libusb\os\poll_windows.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\threads_posix.h" />
+    <ClInclude Include="..\..\libusbx\libusb\os\threads_windows.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\wince_usb.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\windows_common.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\windows_usb.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\version.h" />
+    <ClInclude Include="..\..\libusbx\libusb\version_nano.h" />
+    <ClInclude Include="..\..\libwebsockets\lib\extension-deflate-frame.h" />
+    <ClInclude Include="..\..\libwebsockets\lib\extension-deflate-stream.h" />
+    <ClInclude Include="..\..\libwebsockets\lib\getifaddrs.h" />
+    <ClInclude Include="..\..\libwebsockets\lib\libwebsockets.h" />
+    <ClInclude Include="..\..\libwebsockets\lib\private-libwebsockets.h" />
+    <ClInclude Include="..\..\rapidjson\document.h" />
+    <ClInclude Include="..\..\rapidjson\filestream.h" />
+    <ClInclude Include="..\..\rapidjson\internal\pow10.h" />
+    <ClInclude Include="..\..\rapidjson\internal\stack.h" />
+    <ClInclude Include="..\..\rapidjson\internal\strfunc.h" />
+    <ClInclude Include="..\..\rapidjson\prettywriter.h" />
+    <ClInclude Include="..\..\rapidjson\rapidjson.h" />
+    <ClInclude Include="..\..\rapidjson\reader.h" />
+    <ClInclude Include="..\..\rapidjson\stringbuffer.h" />
+    <ClInclude Include="..\..\rapidjson\writer.h" />
+    <ClInclude Include="..\..\src\config.h" />
+    <ClInclude Include="..\..\src\enttecdmxdevice.h" />
+    <ClInclude Include="..\..\src\fast_mutex.h" />
+    <ClInclude Include="..\..\src\fcdevice.h" />
+    <ClInclude Include="..\..\src\fcserver.h" />
+    <ClInclude Include="..\..\src\opc.h" />
+    <ClInclude Include="..\..\src\tcpnetserver.h" />
+    <ClInclude Include="..\..\src\tinythread.h" />
+    <ClInclude Include="..\..\src\usbdevice.h" />
+    <ClInclude Include="..\..\src\version.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\.gitignore" />
+    <None Include="..\..\..\README.md" />
+    <None Include="..\..\http\404.html">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </None>
+    <None Include="..\..\http\css\narrow.css">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </None>
+    <None Include="..\..\http\dist\css\bootstrap.min.css">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </None>
+    <None Include="..\..\http\dist\js\bootstrap.min.js">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </None>
+    <None Include="..\..\http\dist\js\jquery-1.10.2.min.js">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </None>
+    <None Include="..\..\http\index.html">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </None>
+    <None Include="..\..\http\js\home.js">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </None>
+    <None Include="..\..\http\manifest.py">
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">(cd %(RelativeDir); python %(Identity)) &gt; %(RelativeDir)/../src/httpdocs.cpp</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">(cd %(RelativeDir); python %(Identity)) &gt; %(RelativeDir)/../src/httpdocs.cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">(cd %(RelativeDir); python %(Identity)) &gt; %(RelativeDir)/../src/httpdocs.cpp</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">(cd %(RelativeDir); python %(Identity)) &gt; %(RelativeDir)/../src/httpdocs.cpp</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </Outputs>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</LinkObjects>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</LinkObjects>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</TreatOutputAsContent>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</TreatOutputAsContent>
+    </None>
+    <None Include="..\..\libwebsockets\lib\.gitignore" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\libusbx\libusb\core.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\descriptor.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\hotplug.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\io.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\darwin_usb.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\linux_netlink.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\linux_udev.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">FCSERVER_VERSION=fcserver-1.04-101-g686ab1f;NDEBUG -DLWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">FCSERVER_VERSION=fcserver-1.04-101-g686ab1f;NDEBUG -DLWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\linux_usbfs.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\netbsd_usb.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\openbsd_usb.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\poll_posix.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\poll_windows.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\threads_posix.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\threads_windows.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\wince_usb.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\windows_usb.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\strerror.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\sync.c">
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\base64-decode.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppAdditionalWarning>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppAdditionalWarning>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\client-handshake.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\client-parser.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\client.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\daemonize.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\extension-deflate-frame.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\extension-deflate-stream.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\extension.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\getifaddrs.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\handshake.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppAdditionalWarning>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppAdditionalWarning>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\libwebsockets.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppAdditionalWarning>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppAdditionalWarning>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\minilex.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\output.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppAdditionalWarning>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppAdditionalWarning>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\parsers.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppAdditionalWarning>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppAdditionalWarning>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\server-handshake.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppAdditionalWarning>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppAdditionalWarning>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\server.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppAdditionalWarning>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppAdditionalWarning>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\sha-1.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">_DEFAULT_SOURCE;NDEBUG;LWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppAdditionalWarning>
+      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </WarningLevel>
+      <CAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppAdditionalWarning>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </CppLanguageStandard>
+      <RuntimeTypeInfo Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </RuntimeTypeInfo>
+      <CppLanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </CppLanguageStandard>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </ExceptionHandling>
+      <ThreadSafeStatics Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ThreadSafeStatics>
+      <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </ExceptionHandling>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+      </OmitFramePointers>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+      </OmitFramePointers>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">CompileAsC</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">CompileAsC</CompileAs>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">-MMD</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">-MMD</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="..\..\src\enttecdmxdevice.cpp" />
+    <ClCompile Include="..\..\src\fcdevice.cpp" />
+    <ClCompile Include="..\..\src\fcserver.cpp" />
+    <ClCompile Include="..\..\src\main.cpp" />
+    <ClCompile Include="..\..\src\tcpnetserver.cpp" />
+    <ClCompile Include="..\..\src\tinythread.cpp" />
+    <ClCompile Include="..\..\src\usbdevice.cpp" />
+    <ClCompile Include="..\..\src\version.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\..\http\media\favicon.ico">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </Image>
+    <Image Include="..\..\http\media\favicon.png">
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</RemoteCopyFile>
+      <RemoteCopyFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</RemoteCopyFile>
+    </Image>
+  </ItemGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>FCSERVER_VERSION=fcserver-1.04-101-g686ab1f;NDEBUG -DLWS_LIBRARY_VERSION=;LWS_BUILD_HASH=;LWS_NO_EXTENSIONS;LWS_NO_CLIENT;LWS_NO_WSAPOLL;LWS_NO_DAEMONIZE;OS_LINUX;THREADS_POSIX;POLL_NFDS_TYPE=nfds_t;LIBUSB_CALL=;DEFAULT_VISIBILITY=;HAVE_GETTIMEOFDAY;HAVE_POLL_H;HAVE_ASM_TYPES_H;HAVE_SYS_SOCKET_H;HAVE_LINUX_NETLINK_H;HAVE_LINUX_FILTER_H</PreprocessorDefinitions>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <CppLanguageStandard>gnu++11</CppLanguageStandard>
+      <ExceptionHandling>Disabled</ExceptionHandling>
+      <CAdditionalWarning>no-strict-aliasing</CAdditionalWarning>
+      <CppAdditionalWarning>no-strict-aliasing</CppAdditionalWarning>
+      <Verbose>true</Verbose>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>-lstdc++;-lm;-lpthread;-lrt</AdditionalDependencies>
+      <AdditionalOptions>$(RemoteRootDir)/$(SolutionName)httpdocs.o</AdditionalOptions>
+      <Relocation>
+      </Relocation>
+      <FunctionBinding>false</FunctionBinding>
+      <NoExecStackRequired>false</NoExecStackRequired>
+      <UnresolvedSymbolReferences>
+      </UnresolvedSymbolReferences>
+    </Link>
+    <RemotePreLinkEvent>
+      <Command>(cd server/http; python manifest.py) &gt; $(RemoteRootDir)/$(SolutionName)httpdocs.cpp &amp;&amp; g++ -DFCSERVER_VERSION=fcserver-1.04-101-g686ab1f -std=gnu++0x -felide-constructors -fno-exceptions -fno-rtti -Wno-strict-aliasing -Os -DNDEBUG -DLWS_LIBRARY_VERSION= -DLWS_BUILD_HASH= -DLWS_NO_EXTENSIONS -DLWS_NO_CLIENT -DLWS_NO_WSAPOLL -DLWS_NO_DAEMONIZE -DOS_LINUX -DTHREADS_POSIX -DPOLL_NFDS_TYPE=nfds_t -DLIBUSB_CALL= -DDEFAULT_VISIBILITY= -DHAVE_GETTIMEOFDAY -DHAVE_POLL_H -DHAVE_ASM_TYPES_H -DHAVE_SYS_SOCKET_H -DHAVE_LINUX_NETLINK_H -DHAVE_LINUX_FILTER_H -MMD -Iserver/src -Iserver -lserver/rapidjson -Iserver/libwebsockets/lib -Iserver/libusbx/libusb  -c -o $(RemoteRootDir)/$(SolutionName)httpdocs.o $(RemoteRootDir)/$(SolutionName)httpdocs.cpp</Command>
+      <Message>Generating and compiling httpdocs.cpp</Message>
+    </RemotePreLinkEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/server/vsbuild/vs2017_linux_raspberrypi/server_vs2017_linux_raspberrypi.vcxproj.filters
+++ b/server/vsbuild/vs2017_linux_raspberrypi/server_vs2017_linux_raspberrypi.vcxproj.filters
@@ -1,0 +1,356 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="src">
+      <UniqueIdentifier>{f4d936f6-fee9-440f-82b8-e153a185f8cd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libwebsockets">
+      <UniqueIdentifier>{ae960df6-1f86-4189-bfb7-ab9c5b63e838}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx">
+      <UniqueIdentifier>{f551f232-76e0-4bac-ac00-e1063e88956f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx\os">
+      <UniqueIdentifier>{ba4c6d83-1339-4859-808f-c634164bbd0b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx\os\linux">
+      <UniqueIdentifier>{1389f851-a9c4-4c1d-9ea5-a15a41a6b087}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx\os\posix">
+      <UniqueIdentifier>{d0e0ba4f-88bc-4795-8347-ea71ff5f7be3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx\os\darwin">
+      <UniqueIdentifier>{149930c5-ce5c-4b5b-9f66-af4c06dd0377}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx\os\windows">
+      <UniqueIdentifier>{f8cf92fb-c972-44fc-90e6-77c27b5210e5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx\os\wince">
+      <UniqueIdentifier>{1fa5204b-e426-4fc0-9e05-b76980a4ed99}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx\os\netbsd">
+      <UniqueIdentifier>{715c461b-70d8-4ce3-9daf-92a0270cd52f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libusbx\os\openbsd">
+      <UniqueIdentifier>{1a0a5db0-4d8d-42ef-831b-72d4aeef8e37}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rapidjson">
+      <UniqueIdentifier>{bb496c80-4dd8-4f6c-acd9-52276c818ed4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rapidjson\internal">
+      <UniqueIdentifier>{c217c729-620d-46ca-8666-9ee9308fcdb1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="http">
+      <UniqueIdentifier>{961499f5-4701-4bda-bf0b-4874bbc31ac3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="http\css">
+      <UniqueIdentifier>{e5fd3758-4bfe-43f7-81dd-db9cdc5ef638}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="http\dist">
+      <UniqueIdentifier>{9cf9f43b-cd0d-4523-8919-d8c99ca82e2d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="http\dist\css">
+      <UniqueIdentifier>{0e85c7c8-4fd6-4415-a299-6960d6e23c47}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="http\dist\js">
+      <UniqueIdentifier>{7206ac51-1b73-4b2a-8cd0-57e6726ccc22}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="http\js">
+      <UniqueIdentifier>{197fff70-eda8-4431-b144-5d19923206dd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="http\media">
+      <UniqueIdentifier>{36b7d449-e946-459d-866e-2344e6ba6945}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\config.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\enttecdmxdevice.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\fast_mutex.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\fcdevice.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\fcserver.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\opc.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\tcpnetserver.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\tinythread.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\usbdevice.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\version.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libwebsockets\lib\extension-deflate-frame.h">
+      <Filter>libwebsockets</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libwebsockets\lib\extension-deflate-stream.h">
+      <Filter>libwebsockets</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libwebsockets\lib\getifaddrs.h">
+      <Filter>libwebsockets</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libwebsockets\lib\libwebsockets.h">
+      <Filter>libwebsockets</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libwebsockets\lib\private-libwebsockets.h">
+      <Filter>libwebsockets</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\version_nano.h">
+      <Filter>libusbx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\linux_usbfs.h">
+      <Filter>libusbx\os\linux</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\threads_posix.h">
+      <Filter>libusbx\os\posix</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\poll_posix.h">
+      <Filter>libusbx\os\posix</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\darwin_usb.h">
+      <Filter>libusbx\os\darwin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\poll_windows.h">
+      <Filter>libusbx\os\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\threads_windows.h">
+      <Filter>libusbx\os\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\windows_common.h">
+      <Filter>libusbx\os\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\windows_usb.h">
+      <Filter>libusbx\os\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\os\wince_usb.h">
+      <Filter>libusbx\os\wince</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\hotplug.h">
+      <Filter>libusbx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\libusb.h">
+      <Filter>libusbx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\libusbi.h">
+      <Filter>libusbx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libusbx\libusb\version.h">
+      <Filter>libusbx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\document.h">
+      <Filter>rapidjson</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\filestream.h">
+      <Filter>rapidjson</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\prettywriter.h">
+      <Filter>rapidjson</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\rapidjson.h">
+      <Filter>rapidjson</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\reader.h">
+      <Filter>rapidjson</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\stringbuffer.h">
+      <Filter>rapidjson</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\writer.h">
+      <Filter>rapidjson</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\internal\pow10.h">
+      <Filter>rapidjson\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\internal\stack.h">
+      <Filter>rapidjson\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\rapidjson\internal\strfunc.h">
+      <Filter>rapidjson\internal</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\.gitignore" />
+    <None Include="..\..\..\README.md" />
+    <None Include="..\..\libwebsockets\lib\.gitignore">
+      <Filter>libwebsockets</Filter>
+    </None>
+    <None Include="..\..\http\404.html">
+      <Filter>http</Filter>
+    </None>
+    <None Include="..\..\http\index.html">
+      <Filter>http</Filter>
+    </None>
+    <None Include="..\..\http\dist\css\bootstrap.min.css">
+      <Filter>http\dist\css</Filter>
+    </None>
+    <None Include="..\..\http\css\narrow.css">
+      <Filter>http\css</Filter>
+    </None>
+    <None Include="..\..\http\dist\js\bootstrap.min.js">
+      <Filter>http\dist\js</Filter>
+    </None>
+    <None Include="..\..\http\dist\js\jquery-1.10.2.min.js">
+      <Filter>http\dist\js</Filter>
+    </None>
+    <None Include="..\..\http\js\home.js">
+      <Filter>http\js</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\enttecdmxdevice.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\fcdevice.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\fcserver.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\tcpnetserver.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\tinythread.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\usbdevice.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\version.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\base64-decode.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\client.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\client-handshake.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\client-parser.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\daemonize.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\extension.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\extension-deflate-frame.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\extension-deflate-stream.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\getifaddrs.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\handshake.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\libwebsockets.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\minilex.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\output.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\parsers.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\server.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\server-handshake.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libwebsockets\lib\sha-1.c">
+      <Filter>libwebsockets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\linux_netlink.c">
+      <Filter>libusbx\os\linux</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\linux_udev.c">
+      <Filter>libusbx\os\linux</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\linux_usbfs.c">
+      <Filter>libusbx\os\linux</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\poll_posix.c">
+      <Filter>libusbx\os\posix</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\threads_posix.c">
+      <Filter>libusbx\os\posix</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\darwin_usb.c">
+      <Filter>libusbx\os\darwin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\poll_windows.c">
+      <Filter>libusbx\os\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\threads_windows.c">
+      <Filter>libusbx\os\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\windows_usb.c">
+      <Filter>libusbx\os\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\wince_usb.c">
+      <Filter>libusbx\os\wince</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\netbsd_usb.c">
+      <Filter>libusbx\os\netbsd</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\os\openbsd_usb.c">
+      <Filter>libusbx\os\openbsd</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\core.c">
+      <Filter>libusbx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\descriptor.c">
+      <Filter>libusbx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\hotplug.c">
+      <Filter>libusbx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\io.c">
+      <Filter>libusbx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\strerror.c">
+      <Filter>libusbx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libusbx\libusb\sync.c">
+      <Filter>libusbx</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\..\http\media\favicon.ico">
+      <Filter>http\media</Filter>
+    </Image>
+    <Image Include="..\..\http\media\favicon.png">
+      <Filter>http\media</Filter>
+    </Image>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\http\manifest.py">
+      <Filter>http</Filter>
+    </CustomBuild>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Greetings,

This pull request adds a .sln and .supporting files to allow deployment, remote compilation and debugging of fadecandy on a raspberry pi (and possibly other linux-based hosts) using Visual Studio's Visual C++ for Linux deployment feature.

Here's a doc with more info about it:
https://blogs.msdn.microsoft.com/vcblog/2016/03/30/visual-c-for-linux-development/

I've ensured that it doesn't require any changes to existing fadecandy files and have setup the defines and compiler flags based on observed flags used by the existing make system on the target platform.

This makes it much easier (for me at least) to iterate and debug when targeting raspberry pi when using a Windows-based development environment!

Thanks,
Lance