### PR TITLE
Remove tabs introduced by SPI change

### DIFF
--- a/server/src/apa102spidevice.h
+++ b/server/src/apa102spidevice.h
@@ -1,19 +1,19 @@
 /*
  * Fadecandy driver for the APA102/APA102C/SK9822 via SPI.
- * 
+ *
  * Copyright (c) 2013 Micah Elizabeth Scott
  * Copyright (c) 2017 Lance Gilbert <lance@lancegilbert.us>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -36,45 +36,45 @@ public:
 
     virtual void loadConfiguration(const Value &config);
     virtual void writeMessage(const OPC::Message &msg);
-	virtual void writeMessage(Document &msg);
+    virtual void writeMessage(Document &msg);
     virtual std::string getName();
     virtual void flush();
 
-	static const char* DEVICE_TYPE;
+    static const char* DEVICE_TYPE;
 
-	virtual void describe(rapidjson::Value &object, Allocator &alloc);
+    virtual void describe(rapidjson::Value &object, Allocator &alloc);
 
 private:
     static const uint32_t START_FRAME = 0x00000000;
-	static const uint32_t END_FRAME = 0xFFFFFFFF;
+    static const uint32_t END_FRAME = 0xFFFFFFFF;
     static const uint32_t BRIGHTNESS_MASK = 0xE0;
 
-	union PixelFrame
-	{
-		struct
-		{
-			uint8_t l;
-			uint8_t b;
-			uint8_t g;
-			uint8_t r;
-		};
+    union PixelFrame
+    {
+        struct
+        {
+            uint8_t l;
+            uint8_t b;
+            uint8_t g;
+            uint8_t r;
+        };
 
-		uint32_t value;
-	};
+        uint32_t value;
+    };
 
     const Value *mConfigMap;
-	PixelFrame* mFrameBuffer;
-	PixelFrame* mFlushBuffer;
-	uint32_t mNumLights;
+    PixelFrame* mFrameBuffer;
+    PixelFrame* mFlushBuffer;
+    uint32_t mNumLights;
 
-	// buffer accessor
-	PixelFrame *fbPixel(unsigned num) {
-		return &mFrameBuffer[num + 1];
-	}
+    // buffer accessor
+    PixelFrame *fbPixel(unsigned num) {
+        return &mFrameBuffer[num + 1];
+    }
 
-	void writeBuffer();
-	void writeDevicePixels(Document &msg);
+    void writeBuffer();
+    void writeDevicePixels(Document &msg);
 
     void opcSetPixelColors(const OPC::Message &msg);
-    void opcMapPixelColors(const OPC::Message &msg, const Value &inst);	
+    void opcMapPixelColors(const OPC::Message &msg, const Value &inst);
 };

--- a/server/src/fcserver.cpp
+++ b/server/src/fcserver.cpp
@@ -1,18 +1,18 @@
 /*
  * Open Pixel Control server for Fadecandy
- * 
+ *
  * Copyright (c) 2013 Micah Elizabeth Scott
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -154,10 +154,10 @@ void FCServer::cbOpcMessage(OPC::Message &msg, void *context)
         dev->writeMessage(msg);
     }
 
-	for (std::vector<SPIDevice*>::iterator i = self->mSPIDevices.begin(), e = self->mSPIDevices.end(); i != e; ++i) {
-		SPIDevice *dev = *i;
-		dev->writeMessage(msg);
-	}
+    for (std::vector<SPIDevice*>::iterator i = self->mSPIDevices.begin(), e = self->mSPIDevices.end(); i != e; ++i) {
+        SPIDevice *dev = *i;
+        dev->writeMessage(msg);
+    }
 
     self->mEventMutex.unlock();
 
@@ -283,62 +283,62 @@ void FCServer::usbDeviceLeft(std::vector<USBDevice*>::iterator iter)
 bool FCServer::startSPI()
 {
 #ifdef FCSERVER_HAS_WIRINGPI
-	wiringPiSetup();
+    wiringPiSetup();
 #endif
 
-	for (unsigned i = 0; i < mDevices.Size(); ++i) {
-		const Value &device = mDevices[i];
+    for (unsigned i = 0; i < mDevices.Size(); ++i) {
+        const Value &device = mDevices[i];
 
-		const Value &vtype = device["type"];
-		const Value &vport = device["port"];
-		const Value &vnumLights = device["numLights"];
+        const Value &vtype = device["type"];
+        const Value &vport = device["port"];
+        const Value &vnumLights = device["numLights"];
 
-		if (vtype.IsNull() || (!vtype.IsString() || strcmp(vtype.GetString(), APA102SPIDevice::DEVICE_TYPE))) {
-			continue;
-		}
+        if (vtype.IsNull() || (!vtype.IsString() || strcmp(vtype.GetString(), APA102SPIDevice::DEVICE_TYPE))) {
+            continue;
+        }
 
-		if (vport.IsNull() || (!vport.IsUint())) {
-			continue;
-		}
+        if (vport.IsNull() || (!vport.IsUint())) {
+            continue;
+        }
 
-		if (vnumLights.IsNull() || (!vnumLights.IsUint())) {
-			continue;
-		}
+        if (vnumLights.IsNull() || (!vnumLights.IsUint())) {
+            continue;
+        }
 
-		openAPA102SPIDevice(vport.GetUint(), vnumLights.GetUint());
-	}
+        openAPA102SPIDevice(vport.GetUint(), vnumLights.GetUint());
+    }
 
-	return true;
+    return true;
 }
 
 void FCServer::openAPA102SPIDevice(uint32_t port, int numLights)
 {
-	APA102SPIDevice* dev = new APA102SPIDevice(numLights, mVerbose);
+    APA102SPIDevice* dev = new APA102SPIDevice(numLights, mVerbose);
 
-	int r = dev->open(port);
-	if (r < 0) {
-		if (mVerbose) {
-			std::clog << "Error opening " << dev->getName() << "\n";
-		}
-		delete dev;
-		return;
-	}
+    int r = dev->open(port);
+    if (r < 0) {
+        if (mVerbose) {
+            std::clog << "Error opening " << dev->getName() << "\n";
+        }
+        delete dev;
+        return;
+    }
 
-	for (unsigned i = 0; i < mDevices.Size(); ++i) {
-		if (dev->matchConfiguration(mDevices[i])) {
-			// Found a matching configuration for this device. We're keeping it!
+    for (unsigned i = 0; i < mDevices.Size(); ++i) {
+        if (dev->matchConfiguration(mDevices[i])) {
+            // Found a matching configuration for this device. We're keeping it!
 
-			dev->loadConfiguration(mDevices[i]);
-			dev->writeColorCorrection(mColor);
-			mSPIDevices.push_back(dev);
+            dev->loadConfiguration(mDevices[i]);
+            dev->writeColorCorrection(mColor);
+            mSPIDevices.push_back(dev);
 
-			if (mVerbose) {
-				std::clog << "SPI device " << dev->getName() << " attached.\n";
-			}
-			jsonConnectedDevicesChanged();
-			return;
-		}
-	}
+            if (mVerbose) {
+                std::clog << "SPI device " << dev->getName() << " attached.\n";
+            }
+            jsonConnectedDevicesChanged();
+            return;
+        }
+    }
 }
 
 void FCServer::mainLoop()
@@ -501,16 +501,16 @@ void FCServer::jsonDeviceMessage(rapidjson::Document &message)
                     break;
             }
         }
-		for (unsigned i = 0; i != mSPIDevices.size(); i++) {
-			SPIDevice *spiDev = mSPIDevices[i];
+        for (unsigned i = 0; i != mSPIDevices.size(); i++) {
+            SPIDevice *spiDev = mSPIDevices[i];
 
-			if (spiDev->matchConfiguration(device)) {
-				matched = true;
-				spiDev->writeMessage(message);
-				if (message.HasMember("error"))
-					break;
-			}
-		}
+            if (spiDev->matchConfiguration(device)) {
+                matched = true;
+                spiDev->writeMessage(message);
+                if (message.HasMember("error"))
+                    break;
+            }
+        }
     }
 
     if (!matched) {
@@ -529,11 +529,11 @@ void FCServer::jsonListConnectedDevices(rapidjson::Document &message)
         mUSBDevices[i]->describe(list[i], message.GetAllocator());
     }
 
-	for (unsigned i = 0; i != mSPIDevices.size(); i++) {
-		SPIDevice *spiDev = mSPIDevices[i];
-		list.PushBack(rapidjson::kObjectType, message.GetAllocator());
-		mSPIDevices[i]->describe(list[i], message.GetAllocator());
-	}
+    for (unsigned i = 0; i != mSPIDevices.size(); i++) {
+        SPIDevice *spiDev = mSPIDevices[i];
+        list.PushBack(rapidjson::kObjectType, message.GetAllocator());
+        mSPIDevices[i]->describe(list[i], message.GetAllocator());
+    }
 }
 
 void FCServer::jsonServerInfo(rapidjson::Document &message)

--- a/server/src/fcserver.h
+++ b/server/src/fcserver.h
@@ -1,18 +1,18 @@
 /*
  * Open Pixel Control server for Fadecandy
- * 
+ *
  * Copyright (c) 2013 Micah Elizabeth Scott
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -60,12 +60,12 @@ private:
 
     TcpNetServer mTcpNetServer;
     tthread::recursive_mutex mEventMutex;
-    tthread::thread *mUSBHotplugThread;    
+    tthread::thread *mUSBHotplugThread;
 
     std::vector<USBDevice*> mUSBDevices;
     struct libusb_context *mUSB;
 
-	std::vector<SPIDevice*> mSPIDevices;
+    std::vector<SPIDevice*> mSPIDevices;
 
     static void cbOpcMessage(OPC::Message &msg, void *context);
     static void cbJsonMessage(libwebsocket *wsi, rapidjson::Document &message, void *context);
@@ -80,8 +80,8 @@ private:
 
     static void usbHotplugThreadFunc(void *arg);
 
-	bool startSPI();
-	void openAPA102SPIDevice(uint32_t port, int numLights);
+    bool startSPI();
+    void openAPA102SPIDevice(uint32_t port, int numLights);
 
     // JSON event broadcasters
     void jsonConnectedDevicesChanged();

--- a/server/src/spidevice.cpp
+++ b/server/src/spidevice.cpp
@@ -37,11 +37,11 @@
 #define SPI_FREQUENCY (SPI_FREQUENCY_MHZ*1000000)
 
 SPIDevice::SPIDevice(const char *type, bool verbose)
-	: mTypeString(type),
-	  mVerbose(verbose),
-	  mPort(0)
+    : mTypeString(type),
+      mVerbose(verbose),
+      mPort(0)
 {
-	gettimeofday(&mTimestamp, NULL);
+    gettimeofday(&mTimestamp, NULL);
 }
 
 SPIDevice::~SPIDevice()
@@ -51,90 +51,90 @@ SPIDevice::~SPIDevice()
 
 int SPIDevice::open(uint32_t port)
 {
-	mPort = port;
+    mPort = port;
 
 #ifdef FCSERVER_HAS_WIRINGPI
-	return wiringPiSPISetup(mPort, SPI_FREQUENCY);
+    return wiringPiSPISetup(mPort, SPI_FREQUENCY);
 #else
-	return -1;
+    return -1;
 #endif
 }
 
 void SPIDevice::write(void* buffer, int length)
 {
 #ifdef FCSERVER_HAS_WIRINGPI
-	wiringPiSPIDataRW(mPort, (unsigned char*)buffer, length);
+    wiringPiSPIDataRW(mPort, (unsigned char*)buffer, length);
 #endif
 }
 
 void SPIDevice::writeColorCorrection(const Value &color)
 {
-	// Optional. By default, ignore color correction messages.
+    // Optional. By default, ignore color correction messages.
 }
 
 bool SPIDevice::matchConfiguration(const Value &config)
 {
-	if (!config.IsObject()) {
-		return false;
-	}
+    if (!config.IsObject()) {
+        return false;
+    }
 
-	const Value &vtype = config["type"];
-	const Value &vport = config["port"];
+    const Value &vtype = config["type"];
+    const Value &vport = config["port"];
 
-	if (!vtype.IsNull() && (!vtype.IsString() || strcmp(vtype.GetString(), mTypeString))) {
-		return false;
-	}
+    if (!vtype.IsNull() && (!vtype.IsString() || strcmp(vtype.GetString(), mTypeString))) {
+        return false;
+    }
 
-	if (!vport.IsNull() && (!vport.IsUint() || vport.GetUint() != mPort)) {
-		return false;
-	}
+    if (!vport.IsNull() && (!vport.IsUint() || vport.GetUint() != mPort)) {
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 const SPIDevice::Value *SPIDevice::findConfigMap(const Value &config)
 {
-	const Value &vmap = config["map"];
+    const Value &vmap = config["map"];
 
-	if (vmap.IsArray()) {
-		// The map is optional, but if it exists it needs to be an array.
-		return &vmap;
-	}
+    if (vmap.IsArray()) {
+        // The map is optional, but if it exists it needs to be an array.
+        return &vmap;
+    }
 
-	if (!vmap.IsNull() && mVerbose) {
-		std::clog << "Device configuration 'map' must be an array.\n";
-	}
+    if (!vmap.IsNull() && mVerbose) {
+        std::clog << "Device configuration 'map' must be an array.\n";
+    }
 
-	return 0;
+    return 0;
 }
 
 void SPIDevice::writeMessage(Document &msg)
 {
-	const char *type = msg["type"].GetString();
+    const char *type = msg["type"].GetString();
 
-	if (!strcmp(type, "device_color_correction")) {
-		// Single-device color correction
-		writeColorCorrection(msg["color"]);
-		return;
-	}
+    if (!strcmp(type, "device_color_correction")) {
+        // Single-device color correction
+        writeColorCorrection(msg["color"]);
+        return;
+    }
 
-	msg.AddMember("error", "Unknown device-specific message type", msg.GetAllocator());
+    msg.AddMember("error", "Unknown device-specific message type", msg.GetAllocator());
 }
 
 void SPIDevice::describe(rapidjson::Value &object, Allocator &alloc)
 {
-	object.AddMember("type", mTypeString, alloc);
+    object.AddMember("type", mTypeString, alloc);
 
-	object.AddMember("port", mPort, alloc);
+    object.AddMember("port", mPort, alloc);
 
-	/*
-	* The connection timestamp lets a particular connection instance be identified
-	* reliably, even if the same device connects and disconnects.
-	*
-	* We encode the timestamp as 64-bit millisecond count, so we don't have to worry about
-	* the portability of string/float conversions. This also matches a common JS format.
-	*/
+    /*
+    * The connection timestamp lets a particular connection instance be identified
+    * reliably, even if the same device connects and disconnects.
+    *
+    * We encode the timestamp as 64-bit millisecond count, so we don't have to worry about
+    * the portability of string/float conversions. This also matches a common JS format.
+    */
 
-	uint64_t timestamp = (uint64_t)mTimestamp.tv_sec * 1000 + mTimestamp.tv_usec / 1000;
-	object.AddMember("timestamp", timestamp, alloc);
+    uint64_t timestamp = (uint64_t)mTimestamp.tv_sec * 1000 + mTimestamp.tv_usec / 1000;
+    object.AddMember("timestamp", timestamp, alloc);
 }

--- a/server/src/spidevice.h
+++ b/server/src/spidevice.h
@@ -32,46 +32,46 @@
 class SPIDevice
 {
 public:
-	typedef rapidjson::Value Value;
-	typedef rapidjson::Document Document;
-	typedef rapidjson::MemoryPoolAllocator<> Allocator;
+    typedef rapidjson::Value Value;
+    typedef rapidjson::Document Document;
+    typedef rapidjson::MemoryPoolAllocator<> Allocator;
 
-	SPIDevice(const char *type, bool verbose);
-	virtual ~SPIDevice();
+    SPIDevice(const char *type, bool verbose);
+    virtual ~SPIDevice();
 
-	// Must be opened before any other methods are called.
-	virtual int open(uint32_t port);
+    // Must be opened before any other methods are called.
+    virtual int open(uint32_t port);
 
-	virtual void write(void* buffer, int length);
+    virtual void write(void* buffer, int length);
 
-	// Check a configuration. Does it describe this device?
-	virtual bool matchConfiguration(const Value &config);
+    // Check a configuration. Does it describe this device?
+    virtual bool matchConfiguration(const Value &config);
 
-	// Load a matching configuration
-	virtual void loadConfiguration(const Value &config) = 0;
+    // Load a matching configuration
+    virtual void loadConfiguration(const Value &config) = 0;
 
-	// Handle an incoming OPC message
-	virtual void writeMessage(const OPC::Message &msg) = 0;
+    // Handle an incoming OPC message
+    virtual void writeMessage(const OPC::Message &msg) = 0;
 
-	// Handle a device-specific JSON message
-	virtual void writeMessage(Document &msg);
+    // Handle a device-specific JSON message
+    virtual void writeMessage(Document &msg);
 
-	// Write color LUT from parsed JSON
-	virtual void writeColorCorrection(const Value &color);
+    // Write color LUT from parsed JSON
+    virtual void writeColorCorrection(const Value &color);
 
-	// Describe this device by adding keys to a JSON object
-	virtual void describe(Value &object, Allocator &alloc);
+    // Describe this device by adding keys to a JSON object
+    virtual void describe(Value &object, Allocator &alloc);
 
-	virtual std::string getName() = 0;
+    virtual std::string getName() = 0;
 
-	const char *getTypeString() { return mTypeString; }
+    const char *getTypeString() { return mTypeString; }
 
 protected:
-	struct timeval mTimestamp;
-	const char *mTypeString;
-	bool mVerbose;
-	uint32_t mPort;
+    struct timeval mTimestamp;
+    const char *mTypeString;
+    bool mVerbose;
+    uint32_t mPort;
 
-	// Utilities
-	const Value *findConfigMap(const Value &config);
+    // Utilities
+    const Value *findConfigMap(const Value &config);
 };


### PR DESCRIPTION
scanlime/fadecandy#104 included tab characters.  This replaces them with spaces for consistency with the rest of the codebase.

Also (unintentionally) removes trailing whitespace.  Can undo this part of that's an issue.