### PR TITLE
Compile with 64 bit flags for Mac

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -42,8 +42,8 @@ CXXFLAGS += -DFCSERVER_VERSION=$(VERSION)
 
 ifeq ($(UNAME), Darwin)
 	# Mac OS X (32-bit build)
-	LDFLAGS += -m32
-	CPPFLAGS += -m32 -DHAVE_POLL_H
+	LDFLAGS += -m64
+	CPPFLAGS += -m64 -DHAVE_POLL_H
 
 	ifeq ("$(shell which llvm-gcc)", "")
 		# We want to support all the way back to OS 10.6 (Snow Leopard), which used gcc


### PR DESCRIPTION
This is needed for Mac OS X Catalina because it only supports 64 bit binaries.

When you run this you will see changes to `libusbx` and `libwebsockets` directories. Since these are submodules, I am not sure what the process is for updating them.

I am also not sure if there are any tests to make sure the binary still behaves the same compiled as 64bit vs 32bit.

Fixes #132 